### PR TITLE
build: Remove unused documentation target for scripting

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,0 @@
-version: 1
-builder:
-  configs:
-    - documentation_targets: [Scripting]


### PR DESCRIPTION
The previous version included a configuration for documentation targets that
included Scripting, which is no longer needed. This commit removes the
unnecessary configuration to streamline the build process.