### PR TITLE
build: Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import Scripting // KS1019/Script.swift ~> 0.0.1
 | `concat` | Returns an array of string representation of files |
 | `asArray` | Returns lines of a string as an array |
 
-See [documentation]() for more details.
+See [documentation](https://swiftpackageindex.com/KS1019/Script.swift/documentation) for more details.
 
 ### Using `Script.swift` with [`swift-sh`](https://github.com/mxcl/swift-sh)
 When you want a script, you typically want it in a single file. With usual setup using Swift Package Manager to interact with external libraries, you would end up a directory with `Package.swift`, which is bit much as a script.


### PR DESCRIPTION
Updating the documentation link to point to the Swift Package Index for more details on the functionality provided by `Script.swift`. This change ensures users can easily access detailed information about the package.